### PR TITLE
Migrate to primary / replica, drop master / slave

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,25 +17,25 @@ mariadb_automysqlbackup: yes
 mariadb_backup: no
 
 # Replication settings:
-# * Enable mariadb_replication_master on master server
-# * Enable mariadb_replication_slave on slave server
-# * Enable both if for master-master replication setup
-mariadb_replication_master: False
-mariadb_replication_slave: False
+# * Enable mariadb_replication_primary on primary server
+# * Enable mariadb_replication_replica on replica server
+# * Enable both if for primary-primary replication setup
+mariadb_replication_primary: False
+mariadb_replication_replica: False
 
 # server ID for replication (needs to be unique in replication setups)
 mariadb_server_id: 1
 
-# local replication user (required to be set on masters)
+# local replication user (required to be set on primaries)
 # mariadb_replication_user_local:
 #   user: repl
 #   host: '%'
 #   pass: insecure
 
-# replication master server (required to be set on slaves)
-# mariadb_replication_master_server: db.example.org
+# replication primary server (required to be set on replicas)
+# mariadb_replication_primary_server: db.example.org
 
-# remote replication user (required to be set on slaves)
+# remote replication user (required to be set on replicas)
 # mariadb_replication_user_remote:
 #   user: repl
 #   pass: insecure
@@ -86,8 +86,8 @@ mariadb_mysqld_options_combined:
       - "{{ mariadb_mysqld_charset_options }}"
       - "{{ mariadb_mysqld_network_options }}"
       - "{{ mariadb_mysqld_pki_options }}"
-      - "{{ mariadb_mysqld_bin_log_options if mariadb_replication_master else [] }}"
-      - "{{ mariadb_mysqld_repl_options if (mariadb_replication_master or mariadb_replication_slave) else [] }}"
+      - "{{ mariadb_mysqld_bin_log_options if mariadb_replication_primary else [] }}"
+      - "{{ mariadb_mysqld_repl_options if (mariadb_replication_primary or mariadb_replication_replica) else [] }}"
       - "{{ mariadb_mysqld_options }}"
 
 mariadb_backup_open_files_limit: "65535"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -77,7 +77,7 @@
 
 - name: Include replication tasks
   ansible.builtin.include_tasks: replication.yml
-  when: mariadb_replication_master or mariadb_replication_slave
+  when: mariadb_replication_primary or mariadb_replication_replica
   tags:
     - mariadb_replication
 

--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -11,35 +11,35 @@
         name: "{{ mariadb_replication_user_local.user }}"
         host: "{{ mariadb_replication_user_local.host | default('%') }}"
         password: "{{ mariadb_replication_user_local.pass }}"
-        priv: "*.*:REPLICATION SLAVE"
+        priv: "*.*:REPLICATION REPLICA"
         state: present
         login_unix_socket: /run/mysqld/mysqld.sock
-      when: mariadb_replication_master and mariadb_replication_user_local is defined
+      when: mariadb_replication_primary and mariadb_replication_user_local is defined
 
-    - name: Get replication slave status
+    - name: Get replication replica status
       community.mysql.mysql_replication:
-        mode: getslave
+        mode: getreplica
         login_unix_socket: /run/mysqld/mysqld.sock
       ignore_errors: True
       check_mode: no
-      register: __mariadb_repl_slave_status
-      when: mariadb_replication_slave
+      register: __mariadb_repl_replica_status
+      when: mariadb_replication_replica
 
-    - name: Get replication master status
+    - name: Get replication primary status
       community.mysql.mysql_replication:
-        mode: getmaster
+        mode: getprimary
         login_unix_socket: /run/mysqld/mysqld.sock
-      delegate_to: "{{ mariadb_replication_master_server }}"
-      register: __mariadb_repl_master_status
-      when: mariadb_replication_slave and not __mariadb_repl_slave_status.Is_Slave
+      delegate_to: "{{ mariadb_replication_primary_server }}"
+      register: __mariadb_repl_primary_status
+      when: mariadb_replication_replica and not __mariadb_repl_replica_status.Is_Replica
 
     - name: Configure replication settings
       community.mysql.mysql_replication:
-        mode: changemaster
-        master_host: "{{ mariadb_replication_master_server }}"
-        master_log_file: "{{ __mariadb_repl_master_status.File }}"
-        master_log_pos: "{{ __mariadb_repl_master_status.Position }}"
-        master_user: "{{ mariadb_replication_user_remote.user }}"
-        master_password: "{{ mariadb_replication_user_remote.pass }}"
+        mode: changeprimary
+        primary_host: "{{ mariadb_replication_primary_server }}"
+        primary_log_file: "{{ __mariadb_repl_primary_status.File }}"
+        primary_log_pos: "{{ __mariadb_repl_primary_status.Position }}"
+        primary_user: "{{ mariadb_replication_user_remote.user }}"
+        primary_password: "{{ mariadb_replication_user_remote.pass }}"
         login_unix_socket: /run/mysqld/mysqld.sock
-      when: mariadb_replication_slave and not __mariadb_repl_slave_status.Is_Slave
+      when: mariadb_replication_replica and not __mariadb_repl_replica_status.Is_Replica


### PR DESCRIPTION
This fixes errors, if running with ansible 2.14, due to unsupported param `getslave` which was dropped.

Besides, this change also adjusts internal, private params and relies on `primary`, instead of `master`.