### PR TITLE
add column_case_sensitive option for users

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ mariadb_databases: []
 #     host: localhost
 #     password: insecure
 #     priv: "project.*:All"
+#     column_case_sensitive: true
 mariadb_users: []
 
 # Install automysqlbackup

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,6 +71,7 @@
     password: "{{ item.password }}"
     priv: "{{ item.priv }}"
     login_unix_socket: /run/mysqld/mysqld.sock
+    column_case_sensitive: "{{ item.column_case_sensitive | default(false) }}"
   no_log: true
   with_items:
     - "{{ mariadb_users }}"


### PR DESCRIPTION
Avoid warnings like
```
[WARNING]: Option column_case_sensitive is not provided. The default is now false, so the column's name will be uppercased. The default will be changed to true in community.mysql 4.0.0.
```
and ensure the current default will be used in the future.