### PR TITLE
ansible 12 - handle empty dicts/lists

### DIFF
--- a/templates/etc/mysql/mariadb.conf.d/60-server.cnf.j2
+++ b/templates/etc/mysql/mariadb.conf.d/60-server.cnf.j2
@@ -10,7 +10,9 @@
 {%             endfor %}
 {%           else %}
 {%             for element in config.options %}
+{%               if element | length > 0 %}
 {{ print_config(element) -}}
+{%               endif %}
 {%             endfor %}
 {%           endif %}
 {%         endif %}


### PR DESCRIPTION
avoid printing `None` in jinja2 template using ansible 12

https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_12.html
> templating - Templates resulting in None are no longer automatically converted to an empty string.